### PR TITLE
Fix Postgresql Version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,32 +17,6 @@ provider "google" {
   zone    = "us-central1-c"
 }
 
-# resource "google_compute_network" "vpc_network" {
-#   name                    = "terraform-network"
-#   auto_create_subnetworks = "true"
-# }
-
-# resource "google_compute_instance" "default" {
-#   name         = "terraformed-microvm"
-#   machine_type = "f1-micro"
-#   zone         = "us-central1-a"
-
-#   boot_disk {
-#     initialize_params {
-#       image = "debian-cloud/debian-10"
-#       size  = 30
-#       type  = "pd-standard"
-#     }
-#   }
-
-#   network_interface {
-#     network = "default"
-#     access_config {
-
-#     }
-#   }
-# }
-
 resource "google_project" "my_project" {
     name       = "Quiz Game"
     project_id = var.project_id
@@ -56,13 +30,13 @@ resource "google_app_engine_application" "quizgame" {
 
 resource "google_sql_database_instance" "instance"{
     name = "quiz-game-db-instance"
-    database_version = "POSTGRESQL_11"
+    database_version = "POSTGRES_11"
     region = "us-central1"
     settings {
         tier = "db-f1-micro"
     }
 
-    deletion_protection = "true"
+    deletion_protection = "false"
 }
 
 resource "google_sql_database" "database" {


### PR DESCRIPTION
The [example usage](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) from the doc shows the proper DB version and to use a `delete_protection` to false. Once everything is setup properly, we can then update the config to true.